### PR TITLE
Event-Listing Dokumentation

### DIFF
--- a/app/static/bundle.css
+++ b/app/static/bundle.css
@@ -879,6 +879,13 @@ input, select {
 .eventlisting__docitem {
   margin-bottom: 20px; }
 
+.event-listing__text {
+  font-size: 24px;
+  padding: 40px;
+  font-family: sofia-pro, sans-serif;
+  font-weight: 700;
+  font-style: normal; }
+
 .eventitem {
   text-decoration: none;
   display: block; }

--- a/theme/common.blocks/eventlisting/__text/event-listing__text.scss
+++ b/theme/common.blocks/eventlisting/__text/event-listing__text.scss
@@ -1,0 +1,5 @@
+.event-listing__text {
+    font-size: 24px;
+    padding: 40px;
+    @include bold;
+}

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -56,6 +56,7 @@
 
 @import 'common.blocks/eventlisting/eventlisting';
 @import 'common.blocks/eventlisting/__eventitem/eventlisting__eventitem';
+@import 'common.blocks/eventlisting/__text/event-listing__text';
 
 @import 'common.blocks/eventitem/eventitem';
 @import 'common.blocks/eventitem/__inside/eventitem__inside';


### PR DESCRIPTION
Dieser PR ist dazu da um den neusten Stand der Dashboard-Events zu dokumentieren.

Gelöst:
- Das Styling des Event-Listings ist angepasst und der Issue-Fix bereit zur review.
- Die Positionierung des Bildes auf der Event-Detailseite ist auch angepasst.

Offen:
- Die Event-items werden nicht auf dem Dashboard angezeigt. Die Event-items instancen sind aber vorhanden, da die
div klassen, in Abhängigkeit zu den Events, auf dashboard.html erstellt werden. Allerdings besitzen die Event-items auf
der dashboard.html keine höhe und keine daten. 


